### PR TITLE
Serd for more platforms (bumps req'ment to Julia 1.6)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Serd"
 uuid = "42699a24-3520-5f41-a549-6a478ed667c2"
 license = "MIT"
 authors = ["Evan Patterson <evan@epatters.org>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
@@ -11,5 +11,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 AutoHashEquals = "0.2"
-Serd_jll = "0.30"
-julia = "1.3"
+Serd_jll = "0.30.11"
+julia = "1.6"


### PR DESCRIPTION
Serd_jll is now built for all platforms (including experimental, i.e. Apple Silicon), this bumps the dependency and sets a min version at current Julia LTS, 1.6.